### PR TITLE
Init Kontrol tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
+[submodule "lib/kontrol-cheatcodes"]
+	path = lib/kontrol-cheatcodes
+	url = https://github.com/runtimeverification/kontrol-cheatcodes.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM runtimeverificationinc/kontrol:ubuntu-jammy-0.1.360
+
+COPY . /home/user/workshop
+
+USER root
+RUN chown -R user:user /home/user
+USER user
+
+WORKDIR /home/user/workshop
+
+# TODO:
+# RUN ./run-kontrol.sh
+
+ENTRYPOINT ["/bin/bash"]

--- a/test/kontrol/proofs/MockProof.k.sol
+++ b/test/kontrol/proofs/MockProof.k.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+/// @author: Certora Team
+/// @author: Runtime Verification Team
+// Adapted from
+// https://github.com/Certora/Examples/tree/af4b65cf022c8ca0f1c5b66fa640275d25d5d7ff/CVLByExample/Summarization/WildcardVsExact
+pragma solidity ^0.8.13;
+
+import {Test, console} from "forge-std/Test.sol";
+import {KontrolCheats} from "kontrol-cheatcodes/KontrolCheats.sol";
+
+contract B {
+    function mockedFunction() external pure returns (uint256) {
+        return 0;
+    }
+}
+
+contract A {
+    B public b;
+
+    constructor(address _b) {
+        b = B(_b);
+    }
+
+    function externalFunction() external view returns (uint256) {
+        return b.mockedFunction();
+    }
+}
+
+contract Mock {
+    function mockedFunction() external pure returns (uint256) {
+        return 7;
+    }
+}
+
+contract MockTest is Test, KontrolCheats {
+    A public a;
+    B public b;
+    Mock public mock;
+
+    function setUp() public {
+        b = new B();
+        a = new A(address(b));
+        mock = new Mock();
+    }
+
+    function test_mockCall() public {
+        vm.mockCall(address(b), abi.encodeWithSelector(b.mockedFunction.selector), abi.encode(7));
+        assertEq(a.externalFunction(), 7);
+    }
+
+    function test_mockFunction() public {
+        kevm.mockFunction(address(b), address(mock), abi.encodeWithSelector(b.mockedFunction.selector));
+        assertEq(a.externalFunction(), 7);
+    }
+}


### PR DESCRIPTION
This PR 
- installs `kontrol-cheatcodes` as a submodule
- adds a Dockerfile (to be extended)
- adds `mock*` tests showcasing summarization